### PR TITLE
Remove KEDA skill from index.html and skills.js

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -278,6 +278,13 @@ section {
     gap: 1.5rem;
 }
 
+/* Adjust grid for sections with fewer items */
+.skill-category:nth-last-child(1) .skill-items {
+    grid-template-columns: repeat(2, 1fr);
+    max-width: 400px;
+    margin: 0 auto;
+}
+
 .skill-item {
     text-align: center;
     padding: 1.5rem;

--- a/index.html
+++ b/index.html
@@ -162,10 +162,6 @@
                         <i class="fas fa-ship"></i>
                         <span>Helm</span>
                     </div>
-                    <div class="skill-item">
-                        <i class="fas fa-scale-balanced"></i>
-                        <span>KEDA</span>
-                    </div>
                 </div>
             </div>
         </div>

--- a/js/skills.js
+++ b/js/skills.js
@@ -63,10 +63,6 @@ const skillsData = {
     'Helm': {
         services: ['Charts', 'Releases', 'Templates', 'Values', 'Repositories'],
         description: 'Proficient in Helm package management for Kubernetes.'
-    },
-    'KEDA': {
-        services: ['Event-driven Autoscaling', 'Scalers', 'Metrics', 'Triggers', 'Custom Resources'],
-        description: 'Experience in KEDA autoscaling for Kubernetes.'
     }
 };
 


### PR DESCRIPTION
This pull request makes adjustments to the skills section of a portfolio project by refining the layout for sections with fewer items, removing references to KEDA from the skills list, and updating the corresponding data and HTML structure. Below are the key changes grouped by theme:

### Layout Adjustments:
* Added a new CSS rule to adjust the grid layout for sections with fewer items. This ensures a better visual presentation by limiting the grid to two columns and centering the content (`css/style.css`).

### Removal of KEDA:
* Removed the KEDA skill item from the "Container Orchestration" section in the HTML file (`index.html`).
* Deleted the KEDA entry from the `skillsData` object in the JavaScript file, including its services and description (`js/skills.js`)